### PR TITLE
Revamp landing page with playful kid-friendly design

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,110 +9,651 @@
   <meta property="og:description" content="小学1〜6年生対象・定員15名。ネイティブ講師と英語×学び×遊び。" />
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="ja_JP" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;700&family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap" rel="stylesheet" />
   <style>
     :root{
-      --primary:#ff6f61; /* コーラル */
-      --secondary:#2a9d8f; /* ティール */
-      --accent:#ffd166; /* サンライト */
-      --ink:#233; /* 濃い文字色 */
-      --muted:#5b6b7a;
-      --bg:#fffdfb; /* あたたかい白 */
+      --primary:#ff8ba7;
+      --secondary:#5ec6ff;
+      --accent:#ffe17d;
+      --accent-2:#9becc5;
+      --accent-3:#d8b4fe;
+      --ink:#233041;
+      --muted:#5c6f82;
+      --bg:#fff7ef;
       --card:#ffffff;
-      --shadow: 0 10px 18px rgba(0,0,0,.08);
-      --radius: 16px;
+      --shadow:0 18px 34px rgba(255,139,167,.22);
+      --radius:24px;
     }
-    *{box-sizing:border-box}
-    html,body{margin:0; padding:0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Hiragino Kaku Gothic ProN", "Noto Sans JP", "Yu Gothic", sans-serif; color:var(--ink); background:var(--bg);}
-    a{color:var(--secondary); text-decoration: none}
-    img{max-width:100%; display:block}
-    .container{width:min(1100px, 92%); margin:0 auto}
+    *{box-sizing:border-box;}
+    html,body{
+      margin:0;
+      padding:0;
+      font-family:'M PLUS Rounded 1c', 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', 'Yu Gothic', sans-serif;
+      color:var(--ink);
+      background:var(--bg);
+      line-height:1.6;
+      -webkit-font-smoothing:antialiased;
+    }
+    h1,h2,h3,h4{
+      font-family:'Baloo 2','M PLUS Rounded 1c',cursive;
+      font-weight:700;
+      margin:0;
+    }
+    body::before{
+      content:"";
+      position:fixed;
+      inset:0;
+      pointer-events:none;
+      background:
+        radial-gradient(140px 140px at 15% 20%, rgba(255,255,255,.8) 0, rgba(255,255,255,0) 70%),
+        radial-gradient(220px 220px at 85% 12%, rgba(94,198,255,.18) 0, rgba(94,198,255,0) 70%),
+        radial-gradient(160px 160px at 25% 85%, rgba(255,225,125,.28) 0, rgba(255,225,125,0) 72%);
+      z-index:-1;
+    }
+    a{color:var(--secondary); text-decoration:none; font-weight:600;}
+    a:hover{text-decoration:underline;}
+    img{max-width:100%; display:block;}
+    .container{width:min(1100px,92%); margin:0 auto;}
 
-    /* Header */
-    header{position:sticky; top:0; z-index:50; background:rgba(255,255,255,.9); backdrop-filter: blur(8px); border-bottom:1px solid rgba(0,0,0,.06)}
-    .nav{display:flex; align-items:center; justify-content:space-between; padding:12px 0}
-    .brand{display:flex; align-items:center; gap:10px; font-weight:800; letter-spacing:.5px}
-    .brand-mark{width:36px; height:36px; border-radius:50%; background: conic-gradient(from 180deg, var(--primary), var(--accent), var(--secondary)); box-shadow:var(--shadow); display:grid; place-items:center; color:#fff; font-weight:900}
-    nav ul{display:flex; gap:20px; list-style:none; padding:0; margin:0}
-    nav a{padding:8px 12px; border-radius:10px}
-    nav a:hover{background:rgba(42,157,143,.08)}
-    .cta-btn{background:var(--primary); color:#fff; padding:10px 16px; border-radius:12px; font-weight:700; box-shadow:var(--shadow)}
-    .cta-btn:hover{opacity:.92}
+    header{
+      position:sticky;
+      top:0;
+      z-index:50;
+      background:rgba(255,255,255,.92);
+      backdrop-filter:blur(12px);
+      border-bottom:1px solid rgba(0,0,0,.04);
+      box-shadow:0 12px 24px rgba(32,49,70,.08);
+    }
+    .nav{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      padding:14px 0;
+      gap:16px;
+    }
+    .brand{
+      display:flex;
+      align-items:center;
+      gap:12px;
+      font-weight:800;
+      letter-spacing:.6px;
+    }
+    .brand-mark{
+      width:46px;
+      height:46px;
+      border-radius:50%;
+      background:conic-gradient(from 160deg,var(--primary),var(--accent),var(--secondary));
+      display:grid;
+      place-items:center;
+      color:#fff;
+      font-size:24px;
+      box-shadow:0 10px 18px rgba(255,139,167,.35);
+    }
+    nav ul{
+      display:flex;
+      gap:18px;
+      list-style:none;
+      padding:0;
+      margin:0;
+    }
+    nav a{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      padding:9px 14px;
+      border-radius:999px;
+      background:rgba(255,255,255,.6);
+      box-shadow:0 8px 14px rgba(94,198,255,.12);
+    }
+    nav a:hover{background:rgba(94,198,255,.18); text-decoration:none;}
+    .cta-btn{
+      background:linear-gradient(135deg,var(--primary),var(--accent));
+      color:#fff;
+      padding:11px 22px;
+      border-radius:999px;
+      font-weight:800;
+      box-shadow:0 14px 24px rgba(255,139,167,.35);
+      transition:transform .2s ease, box-shadow .2s ease;
+    }
+    .cta-btn:hover{
+      transform:translateY(-2px);
+      text-decoration:none;
+      box-shadow:0 18px 34px rgba(255,139,167,.4);
+    }
 
-    /* Hero */
-    .hero{position:relative; padding:72px 0 56px; background: radial-gradient(1200px 500px at 20% -10%, rgba(255,111,97,.15), transparent),
-                                     radial-gradient(900px 400px at 90% 10%, rgba(42,157,143,.12), transparent)}
-    .hero-grid{display:grid; gap:28px; grid-template-columns: 1.15fr .85fr; align-items:center}
-    .hero h1{font-size: clamp(28px, 5vw, 44px); line-height:1.2; margin:.2em 0}
-    .subtitle{font-size: clamp(15px, 1.8vw, 18px); color:var(--muted);}
-    .badge-row{display:flex; flex-wrap:wrap; gap:10px; margin:18px 0 26px}
-    .badge{background:#fff; border:1px solid rgba(0,0,0,.06); padding:8px 12px; border-radius:999px; font-weight:700; display:flex; align-items:center; gap:8px; box-shadow:var(--shadow)}
-    .hero-cta{display:flex; gap:12px; flex-wrap:wrap}
-    .btn{display:inline-flex; align-items:center; gap:8px; border:none; cursor:pointer; padding:12px 16px; border-radius:12px; font-weight:700}
-    .btn-primary{background:var(--secondary); color:#fff}
-    .btn-secondary{background:#fff; color:var(--ink); border:1px solid rgba(0,0,0,.08)}
-    .hero-illu{position:relative; background:#fff; border-radius:var(--radius); padding:16px; box-shadow:var(--shadow);}
-    .hero-illu .tag{position:absolute; top:12px; left:12px; background:var(--accent); padding:6px 10px; border-radius:10px; font-weight:800}
-    .hero-illu .grid{display:grid; grid-template-columns:1fr 1fr; gap:10px}
-    .mini-card{background:linear-gradient(180deg, #fff, #fff7f4); border:1px solid rgba(0,0,0,.06); border-radius:14px; padding:10px}
-    .mini-card h4{margin:2px 0 6px; font-size:14px}
-    .mini-card p{margin:0; font-size:12px; color:var(--muted)}
+    .hero{
+      position:relative;
+      padding:90px 0 70px;
+      overflow:hidden;
+      background:linear-gradient(135deg, rgba(255,139,167,.14), rgba(94,198,255,.16));
+    }
+    .hero::before{
+      content:"";
+      position:absolute;
+      width:340px;
+      height:340px;
+      top:-140px;
+      left:-90px;
+      background:radial-gradient(circle at center, rgba(255,255,255,.9), rgba(255,255,255,0));
+      z-index:0;
+    }
+    .hero::after{
+      content:"";
+      position:absolute;
+      width:260px;
+      height:260px;
+      bottom:-120px;
+      right:-60px;
+      background:radial-gradient(circle at center, rgba(155,236,197,.45), rgba(155,236,197,0));
+      z-index:0;
+    }
+    .hero-grid{
+      position:relative;
+      z-index:1;
+      display:grid;
+      gap:32px;
+      grid-template-columns:1.1fr .9fr;
+      align-items:center;
+    }
+    .hero h1{
+      font-size:clamp(30px, 5vw, 48px);
+      line-height:1.15;
+      color:#1e2432;
+    }
+    .hero h1 span{color:var(--primary);}
+    .subtitle{
+      font-size:clamp(16px, 1.9vw, 19px);
+      color:var(--muted);
+      margin-top:12px;
+    }
+    .hero-note{
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      padding:10px 18px;
+      background:#fff;
+      border-radius:999px;
+      font-weight:700;
+      box-shadow:0 10px 20px rgba(35,48,65,.08);
+      margin-top:18px;
+      color:#ff6f8f;
+    }
+    .badge-row{
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+      margin:24px 0 28px;
+    }
+    .badge{
+      background:#fff;
+      padding:9px 14px;
+      border-radius:18px;
+      font-weight:700;
+      display:flex;
+      align-items:center;
+      gap:8px;
+      box-shadow:0 12px 24px rgba(35,48,65,.08);
+      border:2px dashed rgba(255,139,167,.3);
+    }
+    .hero-cta{
+      display:flex;
+      gap:14px;
+      flex-wrap:wrap;
+    }
+    .btn{
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      border:none;
+      cursor:pointer;
+      padding:13px 18px;
+      border-radius:16px;
+      font-weight:800;
+      transition:transform .2s ease, box-shadow .2s ease, opacity .2s ease;
+    }
+    .btn-primary{
+      background:linear-gradient(135deg,var(--secondary),#8fd6ff);
+      color:#0f1e2d;
+      box-shadow:0 12px 24px rgba(94,198,255,.35);
+    }
+    .btn-primary:hover{
+      transform:translateY(-3px);
+      box-shadow:0 16px 34px rgba(94,198,255,.38);
+    }
+    .btn-secondary{
+      background:#fff;
+      color:var(--ink);
+      border:2px solid rgba(94,198,255,.35);
+      box-shadow:0 8px 18px rgba(35,48,65,.08);
+    }
+    .btn-secondary:hover{
+      transform:translateY(-3px);
+      box-shadow:0 12px 24px rgba(35,48,65,.12);
+    }
+    .hero-illu{
+      position:relative;
+      background:linear-gradient(160deg,#fff,rgba(255,247,238,.96));
+      border-radius:var(--radius);
+      padding:22px;
+      box-shadow:var(--shadow);
+      overflow:hidden;
+    }
+    .hero-illu::after{
+      content:"";
+      position:absolute;
+      width:120px;
+      height:120px;
+      background:radial-gradient(circle, rgba(216,180,254,.5), rgba(216,180,254,0));
+      bottom:-20px;
+      right:-10px;
+    }
+    .hero-illu .tag{
+      position:absolute;
+      top:16px;
+      left:16px;
+      background:linear-gradient(135deg,var(--secondary),var(--accent));
+      padding:6px 14px;
+      border-radius:14px;
+      font-weight:800;
+      color:#0f1e2d;
+      box-shadow:0 8px 20px rgba(94,198,255,.25);
+    }
+    .hero-illu .grid{
+      display:grid;
+      grid-template-columns:1fr 1fr;
+      gap:12px;
+      margin-top:20px;
+    }
+    .mini-card{
+      background:linear-gradient(135deg,rgba(255,139,167,.16),rgba(255,139,167,.05));
+      border-radius:18px;
+      padding:14px;
+      border:1px solid rgba(255,139,167,.25);
+    }
+    .mini-card:nth-child(2n){
+      background:linear-gradient(135deg,rgba(94,198,255,.16),rgba(94,198,255,.05));
+      border-color:rgba(94,198,255,.25);
+    }
+    .mini-card h4{
+      margin:0 0 6px;
+      font-size:16px;
+    }
+    .mini-card p{
+      margin:0;
+      font-size:13px;
+      color:var(--muted);
+    }
+    .playmates{
+      display:flex;
+      gap:14px;
+      margin-top:26px;
+    }
+    .kid{
+      flex:1;
+      background:#fff;
+      border-radius:20px;
+      padding:14px;
+      text-align:center;
+      box-shadow:0 14px 26px rgba(35,48,65,.12);
+      position:relative;
+      overflow:hidden;
+      animation:floaty 5s ease-in-out infinite;
+    }
+    .kid:nth-child(2){animation-delay:1s; background:linear-gradient(180deg,#fff,rgba(94,198,255,.12));}
+    .kid:nth-child(3){animation-delay:2s; background:linear-gradient(180deg,#fff,rgba(155,236,197,.15));}
+    .kid span{
+      font-size:34px;
+      display:block;
+    }
+    .kid strong{
+      display:block;
+      margin-top:10px;
+      font-size:16px;
+      color:var(--ink);
+    }
+    .kid small{
+      display:block;
+      margin-top:6px;
+      font-size:12px;
+      color:var(--muted);
+    }
+    @keyframes floaty{
+      0%,100%{transform:translateY(0);}
+      50%{transform:translateY(-8px);}
+    }
 
-    /* Sections */
-    section{padding:64px 0}
-    h2{font-size: clamp(22px, 3.6vw, 32px); margin:0 0 14px}
-    .lead{color:var(--muted); margin:0 0 24px}
-    .cards{display:grid; grid-template-columns:repeat(3, 1fr); gap:18px}
-    .card{background:var(--card); border:1px solid rgba(0,0,0,.06); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow)}
-    .card h3{margin:0 0 8px}
-    .chip{display:inline-block; padding:6px 10px; background:rgba(42,157,143,.1); color:var(--secondary); border-radius:999px; font-size:12px; font-weight:700}
+    section{
+      padding:72px 0;
+      position:relative;
+    }
+    .section-soft{
+      background:linear-gradient(180deg,rgba(255,255,255,.95),rgba(255,247,236,.85));
+    }
+    .section-soft::before{
+      content:"";
+      position:absolute;
+      top:-30px;
+      left:50%;
+      transform:translateX(-50%);
+      width:120px;
+      height:6px;
+      border-radius:999px;
+      background:linear-gradient(90deg,var(--secondary),var(--accent));
+      opacity:.45;
+    }
+    .section-soft .container{position:relative; z-index:1;}
+    .section-fun{
+      background:linear-gradient(180deg,rgba(255,247,236,.92),rgba(155,236,197,.25));
+    }
+    .section-fun .container{position:relative; z-index:1;}
+    .section-white{background:#fff;}
+    .schedule-section{background:linear-gradient(180deg,rgba(94,198,255,.1),rgba(255,247,236,.9));}
 
-    /* Timeline */
-    .timeline{display:grid; gap:14px}
-    .time-item{display:grid; grid-template-columns:110px 1fr; gap:16px; align-items:flex-start}
-    .time-item time{font-weight:800; color:var(--secondary)}
-    .note{font-size:13px; color:var(--muted)}
+    h2{
+      font-size:clamp(26px, 3.8vw, 36px);
+      margin-bottom:14px;
+      color:#1f2534;
+    }
+    .lead{
+      color:var(--muted);
+      margin:0 0 28px;
+      font-size:16px;
+    }
+    .fun-header{
+      text-align:center;
+      margin-bottom:36px;
+    }
+    .fun-header .lead{
+      max-width:720px;
+      margin:0 auto;
+    }
+    .play-cards{
+      display:grid;
+      grid-template-columns:repeat(3,1fr);
+      gap:18px;
+    }
+    .play-card{
+      background:#fff;
+      border-radius:24px;
+      padding:24px 22px;
+      box-shadow:0 18px 34px rgba(35,48,65,.08);
+      border:2px dashed rgba(255,139,167,.25);
+      position:relative;
+      overflow:hidden;
+    }
+    .play-card::after{
+      content:"";
+      position:absolute;
+      width:120px;
+      height:120px;
+      bottom:-40px;
+      right:-20px;
+      background:radial-gradient(circle, rgba(94,198,255,.2), rgba(94,198,255,0));
+    }
+    .play-card:nth-child(2){border-color:rgba(94,198,255,.28);}
+    .play-card:nth-child(3){border-color:rgba(155,236,197,.28);}
+    .play-icon{
+      width:56px;
+      height:56px;
+      border-radius:16px;
+      background:linear-gradient(135deg,var(--primary),rgba(255,139,167,.55));
+      display:grid;
+      place-items:center;
+      font-size:30px;
+      margin-bottom:12px;
+      color:#fff;
+    }
+    .play-card:nth-child(2) .play-icon{
+      background:linear-gradient(135deg,var(--secondary),#8fd6ff);
+      color:#0f1e2d;
+    }
+    .play-card:nth-child(3) .play-icon{
+      background:linear-gradient(135deg,var(--accent-2),#d6ffe8);
+      color:#184427;
+    }
+    .play-card h3{
+      font-size:20px;
+      margin-bottom:8px;
+    }
+    .play-card p{
+      margin:0;
+      color:var(--muted);
+      font-size:14px;
+    }
+    .mini-gallery{
+      display:grid;
+      grid-template-columns:repeat(3,1fr);
+      gap:16px;
+      margin-top:34px;
+    }
+    .gallery-item{
+      background:rgba(255,255,255,.85);
+      border-radius:20px;
+      padding:18px;
+      box-shadow:0 14px 26px rgba(35,48,65,.08);
+      text-align:center;
+      border:1px solid rgba(0,0,0,.05);
+    }
+    .gallery-item span{
+      font-size:28px;
+      display:block;
+      margin-bottom:10px;
+    }
+    .gallery-item strong{
+      display:block;
+      font-size:16px;
+      margin-bottom:6px;
+    }
+    .gallery-item p{
+      margin:0;
+      font-size:13px;
+      color:var(--muted);
+    }
 
-    /* Feature list */
-    .features{display:grid; grid-template-columns: repeat(2,1fr); gap:18px}
-    .feature{display:flex; gap:12px; align-items:flex-start; background:#fff; border:1px solid rgba(0,0,0,.06); border-radius:14px; padding:14px; box-shadow:var(--shadow)}
-    .icon{width:38px; height:38px; border-radius:11px; background:var(--accent); display:grid; place-items:center; font-weight:900}
+    .features{
+      display:grid;
+      grid-template-columns:repeat(2,1fr);
+      gap:18px;
+    }
+    .feature{
+      display:flex;
+      gap:12px;
+      align-items:flex-start;
+      background:rgba(255,255,255,.9);
+      border:1px solid rgba(0,0,0,.04);
+      border-radius:20px;
+      padding:18px;
+      box-shadow:0 12px 24px rgba(35,48,65,.08);
+    }
+    .icon{
+      width:44px;
+      height:44px;
+      border-radius:14px;
+      background:linear-gradient(135deg,var(--accent-3),rgba(216,180,254,.35));
+      display:grid;
+      place-items:center;
+      font-weight:900;
+      font-size:22px;
+    }
+    .note{font-size:13px; color:var(--muted);}
 
-    /* FAQ */
-    details{background:#fff; border:1px solid rgba(0,0,0,.06); border-radius:12px; padding:14px 16px; box-shadow:var(--shadow)}
-    details+details{margin-top:10px}
-    summary{cursor:pointer; font-weight:800}
+    .cards{
+      display:grid;
+      grid-template-columns:repeat(3,1fr);
+      gap:20px;
+    }
+    .card{
+      background:#fff;
+      border-radius:24px;
+      padding:24px;
+      box-shadow:0 18px 34px rgba(35,48,65,.08);
+      border:1px solid rgba(0,0,0,.04);
+      position:relative;
+      overflow:hidden;
+    }
+    .card::before{
+      content:"";
+      position:absolute;
+      width:110px;
+      height:110px;
+      top:-50px;
+      right:-30px;
+      background:radial-gradient(circle, rgba(255,139,167,.25), rgba(255,139,167,0));
+    }
+    .card:nth-child(2)::before{background:radial-gradient(circle, rgba(94,198,255,.25), rgba(94,198,255,0));}
+    .card:nth-child(3)::before{background:radial-gradient(circle, rgba(155,236,197,.25), rgba(155,236,197,0));}
+    .card h3{font-size:20px; margin-bottom:10px;}
+    .card p{margin:0; color:var(--muted); font-size:14px;}
+    .chip{
+      display:inline-block;
+      padding:7px 12px;
+      background:rgba(255,139,167,.18);
+      color:var(--primary);
+      border-radius:999px;
+      font-size:12px;
+      font-weight:700;
+      margin-bottom:14px;
+    }
+    .card:nth-child(2) .chip{background:rgba(94,198,255,.18); color:#1b5f8a;}
+    .card:nth-child(3) .chip{background:rgba(155,236,197,.2); color:#2f8052;}
 
-    /* Contact */
-    form{display:grid; gap:12px}
-    label{font-size:14px; font-weight:700}
-    input, textarea{width:100%; padding:12px; border-radius:10px; border:1px solid rgba(0,0,0,.16)}
-    textarea{min-height:120px}
-    .form-row{display:grid; grid-template-columns:1fr 1fr; gap:12px}
+    .timeline{
+      display:grid;
+      gap:16px;
+      background:rgba(255,255,255,.88);
+      border-radius:24px;
+      padding:24px;
+      box-shadow:0 16px 32px rgba(35,48,65,.08);
+      border:1px solid rgba(0,0,0,.05);
+    }
+    .time-item{
+      display:grid;
+      grid-template-columns:120px 1fr;
+      gap:16px;
+      align-items:flex-start;
+    }
+    .time-item time{font-weight:800; color:var(--secondary); font-size:16px;}
 
-    /* Footer */
-    footer{background:#0f172a; color:#d7e0ea; padding:28px 0}
-    footer a{color:#d7e0ea; text-decoration:underline}
+    .voices{
+      background:linear-gradient(180deg,rgba(94,198,255,.12),rgba(216,180,254,.16));
+    }
+    .bubbles{
+      display:grid;
+      grid-template-columns:repeat(3,1fr);
+      gap:20px;
+    }
+    .bubble-card{
+      background:#fff;
+      border-radius:28px;
+      padding:26px;
+      box-shadow:0 18px 36px rgba(35,48,65,.1);
+      position:relative;
+      overflow:hidden;
+    }
+    .bubble-card::before{
+      content:"";
+      position:absolute;
+      width:80px;
+      height:80px;
+      top:-20px;
+      left:-20px;
+      background:radial-gradient(circle, rgba(255,139,167,.3), rgba(255,139,167,0));
+    }
+    .bubble-card:nth-child(2)::before{background:radial-gradient(circle, rgba(94,198,255,.3), rgba(94,198,255,0));}
+    .bubble-card:nth-child(3)::before{background:radial-gradient(circle, rgba(155,236,197,.32), rgba(155,236,197,0));}
+    .avatar{
+      width:54px;
+      height:54px;
+      border-radius:50%;
+      background:rgba(255,139,167,.2);
+      display:grid;
+      place-items:center;
+      font-size:26px;
+      margin-bottom:14px;
+    }
+    .bubble-card:nth-child(2) .avatar{background:rgba(94,198,255,.2);}
+    .bubble-card:nth-child(3) .avatar{background:rgba(155,236,197,.2);}
+    .bubble-card p{margin:0; color:var(--muted); font-size:14px;}
+    .bubble-card strong{display:block; margin-top:12px; font-size:15px; color:var(--ink);}
 
-    /* Responsive */
+    details{
+      background:#fff;
+      border:1px solid rgba(0,0,0,.06);
+      border-radius:16px;
+      padding:16px 18px;
+      box-shadow:0 12px 24px rgba(35,48,65,.08);
+    }
+    details+details{margin-top:10px;}
+    summary{cursor:pointer; font-weight:800;}
+
+    form{display:grid; gap:14px;}
+    label{font-size:14px; font-weight:700;}
+    input, textarea{
+      width:100%;
+      padding:13px;
+      border-radius:14px;
+      border:1px solid rgba(0,0,0,.12);
+      font-family:inherit;
+      font-size:14px;
+      background:rgba(255,255,255,.95);
+      box-shadow:inset 0 2px 4px rgba(35,48,65,.04);
+    }
+    textarea{min-height:140px; resize:vertical;}
+    .form-row{display:grid; grid-template-columns:1fr 1fr; gap:14px;}
+
+    .cta-banner{
+      background:linear-gradient(120deg,rgba(255,139,167,.32),rgba(94,198,255,.26));
+      color:#1e2432;
+    }
+    .cta-inner{
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      justify-content:space-between;
+      gap:20px;
+    }
+    .cta-inner p{margin:0; max-width:520px; font-size:16px; color:#1f2534;}
+    .cta-banner h2{margin-bottom:8px;}
+
+    footer{
+      background:#16213b;
+      color:#f1f5ff;
+      padding:32px 0;
+    }
+    footer a{color:#ffe17d; text-decoration:underline;}
+
+    @media (max-width: 980px){
+      .hero-grid{grid-template-columns:1fr;}
+      .hero-illu{order:-1;}
+      .play-cards,.cards,.features,.mini-gallery,.bubbles{grid-template-columns:1fr 1fr;}
+    }
     @media (max-width: 900px){
-      .hero-grid{grid-template-columns:1fr}
-      .cards{grid-template-columns:1fr}
-      .features{grid-template-columns:1fr}
-      .time-item{grid-template-columns:90px 1fr}
-      .form-row{grid-template-columns:1fr}
-      nav ul{display:none}
+      nav ul{display:none;}
+    }
+    @media (max-width: 720px){
+      .play-cards,.cards,.features,.mini-gallery,.bubbles{grid-template-columns:1fr;}
+      .form-row{grid-template-columns:1fr;}
+      .cta-inner{flex-direction:column; align-items:flex-start;}
+      .hero-illu .grid{grid-template-columns:1fr;}
+      .playmates{flex-wrap:wrap;}
+      .kid{flex:1 1 calc(50% - 8px);}
+    }
+    @media (max-width: 520px){
+      .kid{flex:1 1 100%;}
+      .hero h1{font-size:32px;}
     }
   </style>
 </head>
 <body>
-  <!-- Header -->
   <header>
     <div class="container nav" aria-label="トップナビゲーション">
       <div class="brand">
         <div class="brand-mark" aria-hidden="true">🌺</div>
         <div>
           <div style="font-size:14px; color:var(--muted); line-height:1">OHANA</div>
-          <div style="font-size:18px; font-weight:900">オハナ放課後児童クラブ</div>
+          <div style="font-size:20px; font-weight:900">オハナ放課後児童クラブ</div>
         </div>
       </div>
       <nav aria-label="サイト内メニュー">
@@ -128,18 +669,17 @@
     </div>
   </header>
 
-  <!-- Hero -->
   <section class="hero">
     <div class="container hero-grid">
       <div>
-        <h1>学校が終わったら、<br>オハナへ。英語×学び×あそび。</h1>
-        <p class="subtitle">小学<span aria-label="1年生から6年生">1〜6年生</span>対象のアフタースクール。<br>ネイティブ講師と自然にふれあう“英語時間”と、
-          宿題サポート・探究あそびで心も体も育てます。</p>
+        <h1>学校が終わったら、<br><span>オハナでワクワクタイム！</span></h1>
+        <p class="subtitle">小学<span aria-label="1年生から6年生">1〜6年生</span>対象のアフタースクール。ネイティブ講師と自然にふれあう“英語時間”と、宿題サポート・探究あそびで心も体も育てます。</p>
+        <p class="hero-note">🌈 放課後を「大好き」で埋めよう！</p>
         <div class="badge-row" aria-label="オハナの基本情報">
           <span class="badge">👧 対象：小1〜小6</span>
           <span class="badge">👥 定員：<strong>15名以内</strong></span>
           <span class="badge">🕒 アフタースクール</span>
-          <span class="badge">🗣️ ネイティブ講師つき</span>
+          <span class="badge">🗣 ネイティブ講師つき</span>
           <span class="badge">💻 オプション：幼児向けプログラミング</span>
         </div>
         <div class="hero-cta">
@@ -167,17 +707,74 @@
             <p>今日の「できた！」をミニ発表で共有</p>
           </div>
         </div>
+        <div class="playmates" aria-hidden="true">
+          <div class="kid">
+            <span>🎨</span>
+            <strong>クラフトデー</strong>
+            <small>色とりどりの作品づくり</small>
+          </div>
+          <div class="kid">
+            <span>🧪</span>
+            <strong>サイエンス実験</strong>
+            <small>わくわく実験で大発見</small>
+          </div>
+          <div class="kid">
+            <span>🎶</span>
+            <strong>English Song</strong>
+            <small>歌って踊って英語チャレンジ</small>
+          </div>
+        </div>
       </div>
     </div>
   </section>
 
-  <!-- About -->
-  <section id="about">
+  <section class="section-fun" aria-label="OHANAのワクワクポイント">
+    <div class="container">
+      <div class="fun-header">
+        <h2>ワクワクいっぱい！OHANAの魅力</h2>
+        <p class="lead">遊ぶ・学ぶ・チャレンジする時間がぎゅっと詰まった放課後。子どもたちが「また行きたい！」と言ってくれる仕掛けをたくさん用意しています。</p>
+      </div>
+      <div class="play-cards" role="list">
+        <article class="play-card" role="listitem">
+          <div class="play-icon">🎉</div>
+          <h3>曜日ごとのテーマ遊び</h3>
+          <p>探究クラフト・サイエンス実験・ボードゲームデーなど、毎日違うテーマでドキドキを体験。</p>
+        </article>
+        <article class="play-card" role="listitem">
+          <div class="play-icon">🌎</div>
+          <h3>英語でおしゃべりチャレンジ</h3>
+          <p>ネイティブ講師と遊びながら、自分の好きなことを伝える力を育てます。</p>
+        </article>
+        <article class="play-card" role="listitem">
+          <div class="play-icon">🤸</div>
+          <h3>からだもこころもリフレッシュ</h3>
+          <p>外遊び・ダンス・ヨガストレッチでエネルギー発散。お友だちとの協力も自然と生まれます。</p>
+        </article>
+      </div>
+      <div class="mini-gallery" role="list">
+        <div class="gallery-item" role="listitem">
+          <span>🌈</span>
+          <strong>カラフルガーデン</strong>
+          <p>校庭の一角をみんなでお花いっぱいに育てています。</p>
+        </div>
+        <div class="gallery-item" role="listitem">
+          <span>🧠</span>
+          <strong>ひらめきミッション</strong>
+          <p>チームで謎解きやSTEAM課題に挑戦する人気プログラム。</p>
+        </div>
+        <div class="gallery-item" role="listitem">
+          <span>🎵</span>
+          <strong>ミニステージ</strong>
+          <p>好きな歌や英語スピーチを発表して、自信アップ！</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="about" class="section-soft">
     <div class="container">
       <h2>オハナについて</h2>
-      <p class="lead">“Ohana”はハワイの言葉で「家族」。
-        私たちは、放課後の時間を「安心・あたたかさ・挑戦」で満たし、
-        子どもたち一人ひとりの「好き」と「できた」を増やします。</p>
+      <p class="lead">“Ohana”はハワイの言葉で「家族」。私たちは、放課後の時間を「安心・あたたかさ・挑戦」で満たし、子どもたち一人ひとりの「好き」と「できた」を増やします。</p>
       <div class="features" style="margin-top:18px">
         <div class="feature">
           <div class="icon">🧑‍🏫</div>
@@ -211,11 +808,10 @@
     </div>
   </section>
 
-  <!-- Programs -->
-  <section id="programs">
+  <section id="programs" class="section-white">
     <div class="container">
       <h2>プログラム</h2>
-      <p class="lead">日々の学童プログラムに加え、英語アクティビティ、<br>ご希望に応じて<strong>幼児向けプログラミング（オプション）</strong>もご用意。</p>
+      <p class="lead">日々の学童プログラムに加え、英語アクティビティ、ご希望に応じて<strong>幼児向けプログラミング（オプション）</strong>もご用意。</p>
       <div class="cards" role="list">
         <article class="card" role="listitem">
           <span class="chip">毎日</span>
@@ -236,8 +832,7 @@
     </div>
   </section>
 
-  <!-- Schedule -->
-  <section id="schedule">
+  <section id="schedule" class="section-soft schedule-section">
     <div class="container">
       <h2>一日の流れ（例）</h2>
       <p class="lead">曜日や季節行事により変更があります。詳細は見学時にご案内します。</p>
@@ -267,8 +862,31 @@
     </div>
   </section>
 
-  <!-- Features/Safety -->
-  <section id="features">
+  <section class="voices" aria-label="子どもたちと保護者の声">
+    <div class="container">
+      <h2>通っているみんなの声</h2>
+      <p class="lead">OHANAには「また行きたい！」を生むひみつがいっぱい。</p>
+      <div class="bubbles">
+        <div class="bubble-card">
+          <div class="avatar" aria-hidden="true">🧒</div>
+          <p>英語のゲームで笑っているうちに、新しい言葉がたくさん言えるようになったよ！</p>
+          <strong>小学2年・Aちゃん</strong>
+        </div>
+        <div class="bubble-card">
+          <div class="avatar" aria-hidden="true">👦</div>
+          <p>宿題タイムがあるからお迎えまでに全部終わる！帰ったら家族で遊ぶ時間が増えました。</p>
+          <strong>小学4年・Rくん</strong>
+        </div>
+        <div class="bubble-card">
+          <div class="avatar" aria-hidden="true">👩‍👧</div>
+          <p>先生が日々の様子をこまめに伝えてくださるので安心。季節イベントも家族で楽しみにしています。</p>
+          <strong>保護者の方より</strong>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="features" class="section-white">
     <div class="container">
       <h2>安心・安全への取り組み</h2>
       <div class="features" style="margin-top:10px">
@@ -280,8 +898,7 @@
     </div>
   </section>
 
-  <!-- FAQ -->
-  <section id="faq">
+  <section id="faq" class="section-soft">
     <div class="container">
       <h2>よくある質問</h2>
       <details>
@@ -307,8 +924,17 @@
     </div>
   </section>
 
-  <!-- Contact -->
-  <section id="contact">
+  <section class="cta-banner" aria-label="季節イベントのご案内">
+    <div class="container cta-inner">
+      <div>
+        <h2>季節イベントも見学できます！</h2>
+        <p>サマーフェスやハロウィンパーティーなど、子どもが主役のイベントを毎シーズン開催。初めての方もお気軽にどうぞ。</p>
+      </div>
+      <a class="btn btn-primary" href="#contact">イベントの相談をする</a>
+    </div>
+  </section>
+
+  <section id="contact" class="section-white">
     <div class="container">
       <h2>見学・お問い合わせ</h2>
       <p class="lead">まずはお気軽にお問い合わせください。フォーム送信のほか、お電話・LINEでもどうぞ。</p>
@@ -356,10 +982,7 @@
   </footer>
 
   <script>
-    // 年号の自動更新
     document.getElementById('year').textContent = new Date().getFullYear();
-
-    // アンカーのスムーススクロール
     document.querySelectorAll('a[href^="#"]').forEach(a=>{
       a.addEventListener('click', e=>{
         const id = a.getAttribute('href');


### PR DESCRIPTION
## Summary
- Refresh the landing page styling with pastel gradients, rounded typefaces, and animated activity badges so the site feels welcoming to kids and families.
- Introduce a new "ワクワクいっぱい！OHANAの魅力" highlight section, playful gallery cards, and testimonial bubbles that showcase the fun learning atmosphere.
- Soften existing sections with themed backgrounds, update CTA areas, and unify button styles to maintain a cohesive, child-friendly experience throughout.

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d153609ccc8324b5d0369f33cf6d13